### PR TITLE
More customization of PIP edge insets

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -153,7 +153,7 @@ class PIPXibViewController: UIViewController, PIPUsable {
     @IBAction private func onUpdatePIPSize(_ sender: UIButton) {
         pipSize = CGSize(width: 100 + Int(arc4random_uniform(100)),
                          height: 100 + Int(arc4random_uniform(100)))
-        setNeedUpdatePIPSize()
+        setNeedsUpdatePIPFrame()
     }
     
     @IBAction private func onDismiss(_ sender: UIButton) {

--- a/PIPKit/Classes/PIPKitEventDispatcher.swift
+++ b/PIPKit/Classes/PIPKitEventDispatcher.swift
@@ -125,33 +125,35 @@ final class PIPKitEventDispatcher {
         var origin = CGPoint.zero
         let pipSize = rootViewController.pipSize
         let pipEdgeInsets = rootViewController.pipEdgeInsets
-        var safeAreaInsets = UIEdgeInsets.zero
+        var edgeInsets = UIEdgeInsets.zero
         
         if #available(iOS 11.0, *) {
-            safeAreaInsets = window.safeAreaInsets
+            if rootViewController.insetsPIPFromSafeArea {
+                edgeInsets = window.safeAreaInsets
+            }
         }
         
         switch pipPosition {
         case .topLeft:
-            origin.x = safeAreaInsets.left + pipEdgeInsets.left
-            origin.y = safeAreaInsets.top + pipEdgeInsets.top
+            origin.x = edgeInsets.left + pipEdgeInsets.left
+            origin.y = edgeInsets.top + pipEdgeInsets.top
         case .middleLeft:
-            origin.x = safeAreaInsets.left + pipEdgeInsets.left
-            let vh = (window.frame.height - (safeAreaInsets.top + safeAreaInsets.bottom)) / 3.0
-            origin.y = safeAreaInsets.top + (vh * 2.0) - ((vh + pipSize.height) / 2.0)
+            origin.x = edgeInsets.left + pipEdgeInsets.left
+            let vh = (window.frame.height - (edgeInsets.top + edgeInsets.bottom)) / 3.0
+            origin.y = edgeInsets.top + (vh * 2.0) - ((vh + pipSize.height) / 2.0)
         case .bottomLeft:
-            origin.x = safeAreaInsets.left + pipEdgeInsets.left
-            origin.y = window.frame.height - safeAreaInsets.bottom - pipEdgeInsets.bottom - pipSize.height
+            origin.x = edgeInsets.left + pipEdgeInsets.left
+            origin.y = window.frame.height - edgeInsets.bottom - pipEdgeInsets.bottom - pipSize.height
         case .topRight:
-            origin.x = window.frame.width - safeAreaInsets.right - pipEdgeInsets.right - pipSize.width
-            origin.y = safeAreaInsets.top + pipEdgeInsets.top
+            origin.x = window.frame.width - edgeInsets.right - pipEdgeInsets.right - pipSize.width
+            origin.y = edgeInsets.top + pipEdgeInsets.top
         case .middleRight:
-            origin.x = window.frame.width - safeAreaInsets.right - pipEdgeInsets.right - pipSize.width
-            let vh = (window.frame.height - (safeAreaInsets.top + safeAreaInsets.bottom)) / 3.0
-            origin.y = safeAreaInsets.top + (vh * 2.0) - ((vh + pipSize.height) / 2.0)
+            origin.x = window.frame.width - edgeInsets.right - pipEdgeInsets.right - pipSize.width
+            let vh = (window.frame.height - (edgeInsets.top + edgeInsets.bottom)) / 3.0
+            origin.y = edgeInsets.top + (vh * 2.0) - ((vh + pipSize.height) / 2.0)
         case .bottomRight:
-            origin.x = window.frame.width - safeAreaInsets.right - pipEdgeInsets.right - pipSize.width
-            origin.y = window.frame.height - safeAreaInsets.bottom - pipEdgeInsets.bottom - pipSize.height
+            origin.x = window.frame.width - edgeInsets.right - pipEdgeInsets.right - pipSize.width
+            origin.y = window.frame.height - edgeInsets.bottom - pipEdgeInsets.bottom - pipSize.height
         }
         
         rootViewController.view.frame = CGRect(origin: origin, size: pipSize)
@@ -202,21 +204,23 @@ final class PIPKitEventDispatcher {
             let transition = gesture.translation(in: window)
             let pipSize = rootViewController.pipSize
             let pipEdgeInsets = rootViewController.pipEdgeInsets
-            var safeAreaInsets = UIEdgeInsets.zero
+            var edgeInsets = UIEdgeInsets.zero
             
             if #available(iOS 11.0, *) {
-                safeAreaInsets = window.safeAreaInsets
+                if rootViewController.insetsPIPFromSafeArea {
+                    edgeInsets = window.safeAreaInsets
+                }
             }
             
             var offset = startOffset
             offset.x += transition.x
             offset.y += transition.y
-            offset.x = max(safeAreaInsets.left + pipEdgeInsets.left + (pipSize.width / 2.0),
+            offset.x = max(edgeInsets.left + pipEdgeInsets.left + (pipSize.width / 2.0),
                            min(offset.x,
-                               (window.frame.width - safeAreaInsets.right - pipEdgeInsets.right) - (pipSize.width / 2.0)))
-            offset.y = max(safeAreaInsets.top + pipEdgeInsets.top + (pipSize.height / 2.0),
+                               (window.frame.width - edgeInsets.right - pipEdgeInsets.right) - (pipSize.width / 2.0)))
+            offset.y = max(edgeInsets.top + pipEdgeInsets.top + (pipSize.height / 2.0),
                            min(offset.y,
-                               (window.frame.height - (safeAreaInsets.bottom) - pipEdgeInsets.bottom) - (pipSize.height / 2.0)))
+                               (window.frame.height - (edgeInsets.bottom) - pipEdgeInsets.bottom) - (pipSize.height / 2.0)))
             
             rootViewController.view.center = offset
         case .ended:

--- a/PIPKit/Classes/PIPKitEventDispatcher.swift
+++ b/PIPKit/Classes/PIPKitEventDispatcher.swift
@@ -16,7 +16,6 @@ final class PIPKitEventDispatcher {
     }()
     
     var pipPosition: PIPPosition
-    var pipEdgeInsets: UIEdgeInsets
     
     private var startOffset: CGPoint = .zero
     private var deviceNotificationObserver: NSObjectProtocol?
@@ -30,7 +29,6 @@ final class PIPKitEventDispatcher {
     init(rootViewController: PIPKitViewController) {
         self.rootViewController = rootViewController
         self.pipPosition = rootViewController.initialPosition
-        self.pipEdgeInsets = rootViewController.pipEdgeInsets
         
         commonInit()
         updateFrame()
@@ -126,6 +124,7 @@ final class PIPKitEventDispatcher {
         
         var origin = CGPoint.zero
         let pipSize = rootViewController.pipSize
+        let pipEdgeInsets = rootViewController.pipEdgeInsets
         var safeAreaInsets = UIEdgeInsets.zero
         
         if #available(iOS 11.0, *) {
@@ -202,6 +201,7 @@ final class PIPKitEventDispatcher {
         case .changed:
             let transition = gesture.translation(in: window)
             let pipSize = rootViewController.pipSize
+            let pipEdgeInsets = rootViewController.pipEdgeInsets
             var safeAreaInsets = UIEdgeInsets.zero
             
             if #available(iOS 11.0, *) {

--- a/PIPKit/Classes/PIPUsable.swift
+++ b/PIPKit/Classes/PIPUsable.swift
@@ -4,6 +4,7 @@ import UIKit
 public protocol PIPUsable {
     var initialState: PIPState { get }
     var initialPosition: PIPPosition { get }
+    var insetsPIPFromSafeArea: Bool { get }
     var pipEdgeInsets: UIEdgeInsets { get }
     var pipSize: CGSize { get }
     var pipShadow: PIPShadow? { get }
@@ -15,6 +16,7 @@ public protocol PIPUsable {
 public extension PIPUsable {
     var initialState: PIPState { return .pip }
     var initialPosition: PIPPosition { return .bottomRight }
+    var insetsPIPFromSafeArea: Bool { return true }
     var pipEdgeInsets: UIEdgeInsets { return UIEdgeInsets(top: 15, left: 15, bottom: 15, right: 15) }
     var pipSize: CGSize { return CGSize(width: 200.0, height: (200.0 * 9.0) / 16.0) }
     var pipShadow: PIPShadow? { return PIPShadow(color: .black, opacity: 0.3, offset: CGSize(width: 0, height: 8), radius: 10) }

--- a/PIPKit/Classes/PIPUsable.swift
+++ b/PIPKit/Classes/PIPUsable.swift
@@ -31,7 +31,7 @@ public extension PIPUsable {
 
 public extension PIPUsable where Self: UIViewController {
     
-    func setNeedUpdatePIPSize() {
+    func setNeedsUpdatePIPFrame() {
         guard PIPKit.isPIP else {
             return
         }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ class PIPKit {
 
 #### PIPKitViewController (UIViewController & PIPUsable)
 ```swift
-func setNeedUpdatePIPSize()
+func setNeedsUpdatePIPFrame()
 func startPIPMode()
 func stopPIPMode()
 ```
@@ -88,7 +88,8 @@ PIPKit.dismiss(animated: true)
 class PIPViewController: UIViewController, PIPUsable {
     func updatePIPSize() {
         pipSize = CGSize()
-        setNeedUpdatePIPSize()
+        pipEdgeInsets = UIEdgeInsets()
+        setNeedsUpdatePIPFrame()
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ github "Kofktu/PIPKit"
 public protocol PIPUsable {
     var initialState: PIPState { get }
     var initialPosition: PIPPosition { get }
+    var insetsPIPFromSafeArea: Bool { get }
     var pipEdgeInsets: UIEdgeInsets { get }
     var pipSize: CGSize { get }
     var pipShadow: PIPShadow? { get }


### PR DESCRIPTION
This PR 
- Adds the ability to change the PIP edge insets. Currently it only gets them from PIPUsable on init. This changes `pipEdgeInsets` to work like `pipSize` which is changeable.
- Adds the ability to disable insetting PIP to the safe area.
- Renames `setNeedUpdatePIPSize` to `setNeedsUpdatePIPFrame` to be more accurate as it'll now look at your size and edge insets. :) 

This allows us to use different insets when in landscape vs portrait and move it into the safe area as needed.